### PR TITLE
Added possibility to switch between highligth.js themes

### DIFF
--- a/data/com.github.fabiocolacio.marker.gschema.xml
+++ b/data/com.github.fabiocolacio.marker.gschema.xml
@@ -63,6 +63,12 @@
       <summary>Enable highlight.js in Preview</summary>
       <description>Use highlight.js in the live preview.</description>
     </key>
+
+    <key name="highlight-theme" type="s">
+      <default>'default'</default>
+      <summary>Highlight.js CSS theme.</summary>
+      <description>The css theme to use for the synthax highlight.</description>
+    </key>
   </schema>
   
   <schema path="/com/github/fabiocolacio/marker/preferences/window/" id="com.github.fabiocolacio.marker.preferences.window">

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ DATA_DIR = join_paths(PREFIX, 'share')
 APP_DIR = join_paths(DATA_DIR, 'com.github.fabiocolacio.marker')
 STYLES_DIR = join_paths(APP_DIR, 'styles')
 SCRIPTS_DIR = join_paths(APP_DIR, 'scripts')
+HIGHLIGHT_STYLES_DIR = join_paths(join_paths(SCRIPTS_DIR, 'highlight'),'styles')
 
 EXECUTABLE_NAME = 'com.github.fabiocolacio.marker'
 
@@ -54,6 +55,7 @@ deps = [
 add_global_arguments(
   '-DSTYLES_DIR="@0@/"'.format(STYLES_DIR),
   '-DSCRIPTS_DIR="@0@/"'.format(SCRIPTS_DIR),
+  '-DHIGHLIGHT_STYLES_DIR="@0@/"'.format(HIGHLIGHT_STYLES_DIR),
   '-DMARKER_VERSION="@0@"'.format(meson.project_version()),
   language : 'c'
 )

--- a/src/hoedown/html.c
+++ b/src/hoedown/html.c
@@ -96,7 +96,18 @@ static void
 rndr_blockcode(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_buffer *lang, const hoedown_renderer_data *data)
 {
 	if (ob->size) hoedown_buffer_putc(ob, '\n');
+	hoedown_html_renderer_state *state = data->opaque;
 
+	if (lang && (state->flags & HOEDOWN_HTML_CHART) != 0 && hoedown_buffer_eq(lang, "chart", 5)){
+		if (text){
+			HOEDOWN_BUFPUTSL(ob, "<canvas id=\"chart_0\" width=\"400\" height=\"400\"></canvas><script>");
+			HOEDOWN_BUFPUTSL(ob, "var ctx =  document.getElementById(\"chart_0\");");
+			HOEDOWN_BUFPUTSL(ob, "var chart = new Chart(ctx, {");
+			hoedown_buffer_put(ob, text->data, text->size);
+			HOEDOWN_BUFPUTSL(ob, "});</script>");
+		}
+		return;
+	}
 	if (lang) {
 		HOEDOWN_BUFPUTSL(ob, "<pre><code class=\"language-");
 		escape_html(ob, lang->data, lang->size);

--- a/src/hoedown/html.h
+++ b/src/hoedown/html.h
@@ -19,7 +19,8 @@ typedef enum hoedown_html_flags {
 	HOEDOWN_HTML_SKIP_HTML = (1 << 0),
 	HOEDOWN_HTML_ESCAPE = (1 << 1),
 	HOEDOWN_HTML_HARD_WRAP = (1 << 2),
-	HOEDOWN_HTML_USE_XHTML = (1 << 3)
+	HOEDOWN_HTML_USE_XHTML = (1 << 3),
+	HOEDOWN_HTML_CHART = (1 << 4) /* < experimental flag */
 } hoedown_html_flags;
 
 typedef enum hoedown_html_tag {

--- a/src/marker-editor-window.c
+++ b/src/marker-editor-window.c
@@ -242,9 +242,10 @@ marker_editor_window_refresh_preview(MarkerEditorWindow* window)
   gchar* markdown = marker_editor_window_get_markdown(window);
   const char* css_theme = marker_prefs_get_css_theme();
 
+
   gchar* uri = NULL;
   if (G_IS_FILE(window->file)) { uri = g_file_get_uri(window->file); }
-  
+
   marker_preview_render_markdown(window->web_view, markdown, css_theme, uri);
   
   if (uri) { g_free(uri); }

--- a/src/marker-markdown.c
+++ b/src/marker-markdown.c
@@ -9,9 +9,9 @@
 #include "hoedown/buffer.h"
 
 #include "marker-markdown.h"
+#include "marker-prefs.h"
 
-char* 
-html_header(MarkerKaTeXMode     katex_mode,
+char* html_header(MarkerKaTeXMode     katex_mode,
           MarkerHighlightMode highlight_mode)
 {
   char* katex_script;
@@ -20,6 +20,8 @@ html_header(MarkerKaTeXMode     katex_mode,
 
   char* highlight_css;
   char* highlight_script;
+
+  char * local_highlight_css = marker_prefs_get_highlight_theme();
 
   switch (katex_mode) {
     case KATEX_OFF:
@@ -45,11 +47,12 @@ html_header(MarkerKaTeXMode     katex_mode,
       highlight_script = g_strdup(" ");
       break;
     case HIGHLIGHT_NET:
-      highlight_css = g_strdup("<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css\">");
+      highlight_css = g_strdup_printf("<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/%s.min.css\">",
+                                      local_highlight_css);
       highlight_script = g_strdup("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js\"></script>");
       break;
     case HIGHLIGHT_LOCAL:
-      highlight_css = g_strdup_printf("<link rel=\"stylesheet\" href=\"%shighlight/styles/default.css\">", SCRIPTS_DIR);
+      highlight_css = g_strdup_printf("<link rel=\"stylesheet\" href=\"%shighlight/styles/%s.css\">", SCRIPTS_DIR, local_highlight_css);
       highlight_script = g_strdup_printf("<script src=\"%shighlight/highlight.pack.js\"></script>", SCRIPTS_DIR);
       break;
   }
@@ -58,6 +61,7 @@ html_header(MarkerKaTeXMode     katex_mode,
                                   "<html>\n"
                                   "<head>\n"
                                   "%s\n%s\n%s\n%s\n%s\n"
+			          "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js\"></script>"
                                   "<meta charset=\"utf-8\">\n",
                                   katex_css, highlight_css, katex_script, katex_auto, highlight_script);
 
@@ -67,6 +71,7 @@ html_header(MarkerKaTeXMode     katex_mode,
 
   g_free(highlight_css);
   g_free(highlight_script);
+  g_free(local_highlight_css);
 
   return buffer;
 }
@@ -119,8 +124,8 @@ marker_markdown_to_html(const char*         markdown,
   hoedown_renderer* renderer;
   hoedown_document* document;
   hoedown_buffer* buffer;
-  
-  renderer = hoedown_html_renderer_new(0,0);
+
+  renderer = hoedown_html_renderer_new(HOEDOWN_HTML_CHART,0);
   
   document = hoedown_document_new(renderer,
                                   HOEDOWN_EXT_BLOCK         |
@@ -191,15 +196,15 @@ marker_markdown_to_html_with_css_inline(const char*         markdown,
 
     inline_css = (char*) malloc(sizeof(char) * size);
     fread(inline_css, 1, size, fp);
-    
+
     fclose(fp);
   }
-    
+
   hoedown_renderer* renderer;
   hoedown_document* document;
   hoedown_buffer* buffer;
-  
-  renderer = hoedown_html_renderer_new(0,0);
+
+  renderer = hoedown_html_renderer_new(HOEDOWN_HTML_CHART,0);
   
   document = hoedown_document_new(renderer,
                                   HOEDOWN_EXT_BLOCK         |

--- a/src/marker-markdown.c
+++ b/src/marker-markdown.c
@@ -61,7 +61,6 @@ char* html_header(MarkerKaTeXMode     katex_mode,
                                   "<html>\n"
                                   "<head>\n"
                                   "%s\n%s\n%s\n%s\n%s\n"
-			          "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js\"></script>"
                                   "<meta charset=\"utf-8\">\n",
                                   katex_css, highlight_css, katex_script, katex_auto, highlight_script);
 

--- a/src/marker-prefs.h
+++ b/src/marker-prefs.h
@@ -51,6 +51,12 @@ marker_prefs_get_css_theme();
 void
 marker_prefs_set_css_theme(const char* theme);
 
+char*
+marker_prefs_get_highlight_theme();
+
+void
+marker_prefs_set_highlight_theme(const char* theme);
+
 gboolean
 marker_prefs_get_use_katex();
 

--- a/src/marker-preview.c
+++ b/src/marker-preview.c
@@ -2,16 +2,50 @@
 #include <stdlib.h>
 
 #include <glib.h>
+#include <time.h>
 
 #include "marker-markdown.h"
 #include "marker-prefs.h"
 
 #include "marker-preview.h"
+#include "marker.h"
 
 struct _MarkerPreview
 {
   WebKitWebView parent_instance;
 };
+
+/* Open uri in default browser.
+ */
+static
+void open_uri(WebKitResponsePolicyDecision *decision){
+  const gchar * uri = webkit_uri_request_get_uri(webkit_response_policy_decision_get_request(decision));
+  g_print("open %s\n", uri);
+  GtkApplication * app = marker_get_app();
+  GList* windows = gtk_application_get_windows(app);
+  time_t now = time(0); // Get the system time
+  gtk_show_uri_on_window (windows->data,
+                          uri,
+                          now,NULL);
+}
+
+static gboolean
+decide_policy_cb (WebKitWebView *web_view,
+                  WebKitPolicyDecision *decision,
+                  WebKitPolicyDecisionType type)
+{
+    switch (type) {
+    case WEBKIT_POLICY_DECISION_TYPE_RESPONSE:
+        /* ignore default policy and open uri in default browser*/
+        open_uri((WebKitResponsePolicyDecision*)decision);
+        webkit_policy_decision_ignore(decision);
+        break;
+    default:
+        /* Making no decision results in webkit_policy_decision_use(). */
+        return FALSE;
+    }
+    return TRUE;
+}
 
 G_DEFINE_TYPE(MarkerPreview, marker_preview, WEBKIT_TYPE_WEB_VIEW)
 
@@ -71,6 +105,11 @@ marker_preview_render_markdown(MarkerPreview* preview,
   char* html = marker_markdown_to_html(markdown, strlen(markdown), katex_mode, highlight_mode, css_theme);
   const char* uri = (base_uri) ? base_uri : "file://";
   WebKitWebView* web_view = WEBKIT_WEB_VIEW(preview);
+  g_signal_connect(web_view,
+                   "decide-policy",
+                   G_CALLBACK(decide_policy_cb),
+                   NULL);
+
   webkit_web_view_load_html(web_view, html, uri);
   free(html);
 }
@@ -112,4 +151,5 @@ marker_preview_print_pdf(MarkerPreview* preview,
 
     g_free(uri);
 }
+
 

--- a/src/marker-preview.c
+++ b/src/marker-preview.c
@@ -47,6 +47,17 @@ decide_policy_cb (WebKitWebView *web_view,
     return TRUE;
 }
 
+
+static gboolean
+disable_menu  (WebKitWebView       *web_view,
+               WebKitContextMenu   *context_menu,
+               GdkEvent            *event,
+               WebKitHitTestResult *hit_test_result,
+               gpointer             user_data)
+{
+  return TRUE;
+}
+
 G_DEFINE_TYPE(MarkerPreview, marker_preview, WEBKIT_TYPE_WEB_VIEW)
 
 MarkerPreview*
@@ -105,9 +116,14 @@ marker_preview_render_markdown(MarkerPreview* preview,
   char* html = marker_markdown_to_html(markdown, strlen(markdown), katex_mode, highlight_mode, css_theme);
   const char* uri = (base_uri) ? base_uri : "file://";
   WebKitWebView* web_view = WEBKIT_WEB_VIEW(preview);
+
   g_signal_connect(web_view,
                    "decide-policy",
                    G_CALLBACK(decide_policy_cb),
+                   NULL);
+  g_signal_connect(web_view,
+                   "context-menu",
+                   G_CALLBACK(disable_menu),
                    NULL);
 
   webkit_web_view_load_html(web_view, html, uri);

--- a/src/marker-string.c
+++ b/src/marker-string.c
@@ -146,6 +146,23 @@ marker_string_filename_get_name(const char* filename)
 }
 
 char*
+marker_string_filename_get_name_noext(const char* filename)
+{
+  char* name = marker_string_filename_get_name(filename);
+  size_t len = strlen(name);
+  for (int i = len; i > 0; --i){
+    if (filename[i] == '.')
+    {
+      char *ret = (char*) malloc(i+1);
+      memset(ret, 0, i+1);
+      memcpy(ret, filename, i);
+      return ret;
+    }
+  }
+  return name;
+}
+
+char*
 marker_string_filename_get_path(const char* filename)
 {
   size_t len = strlen(filename);

--- a/src/marker-string.h
+++ b/src/marker-string.h
@@ -34,5 +34,7 @@ marker_string_filename_get_path(const char* filename);
 char*
 marker_string_filename_get_name(const char* filename);
 
+char*
+marker_string_filename_get_name_noext(const char* filename);
 #endif
 

--- a/src/marker-widget.c
+++ b/src/marker-widget.c
@@ -75,6 +75,7 @@ marker_widget_combo_box_set_active_str(GtkComboBox* combo_box,
     }
     if (!found)
     {
+      printf("not found: %s\n", str);
       gtk_combo_box_set_active(combo_box, 0);
     }
   }

--- a/src/resources/ui/prefs-window.ui
+++ b/src/resources/ui/prefs-window.ui
@@ -212,6 +212,42 @@
                 <property name="position">1</property>
               </packing>
             </child>
+	    <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label">Highlight Theme: </property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="highlight_css_chooser">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <signal name="changed" handler="highlight_css_chosen" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
             <child>
               <object class="GtkCheckButton" id="highlight_check_button">
                 <property name="label" translatable="yes">Enable Highlight</property>


### PR DESCRIPTION
Patch to close issue #61 
 
**Note**: I included ```marker-prefs.h``` in ```marker-markdown.c``` to avoid to add a new argument to all the functions (in this way I retrieve the highlight theme directly in the function).
If you prefer to add an argument instead just tell me.