### PR TITLE
Figure Caption and Numbering added to Hoedown

### DIFF
--- a/data/com.github.fabiocolacio.marker.gschema.xml
+++ b/data/com.github.fabiocolacio.marker.gschema.xml
@@ -123,6 +123,16 @@
       <summary>Highlight.js CSS theme.</summary>
       <description>The css theme to use for the synthax highlight.</description>
     </key>
+    <key name="figure-caption-toggle" type="b">
+      <default>false</default>
+      <summary>Enable figure caption in Preview</summary>
+      <description>Display title or alt text as caption in the live preview.</description>
+    </key>
+    <key name="figure-numbering-toggle" type="b">
+      <default>false</default>
+      <summary>Enable figure numbering in Preview</summary>
+      <description>Enable and display figure numbering in the live preview (when figure-caption-toggle is enabled).</description>
+    </key>
   </schema>
   
   <schema path="/com/github/fabiocolacio/marker/preferences/window/" id="com.github.fabiocolacio.marker.preferences.window">

--- a/data/styles/GitHub.css
+++ b/data/styles/GitHub.css
@@ -91,3 +91,8 @@ kbd {
 		word-wrap: break-word;
 	}
 }
+
+figure figcaption {
+	text-align: center;
+	font-size: 10px;
+  }

--- a/data/styles/GitHub2.css
+++ b/data/styles/GitHub2.css
@@ -310,3 +310,8 @@ kbd {
 		word-wrap: break-word;
 	}
 }
+
+figure figcaption {
+  text-align: center;
+  font-size: 12px;
+}

--- a/data/styles/Solarized (Dark).css
+++ b/data/styles/Solarized (Dark).css
@@ -197,3 +197,8 @@ kbd {
     color: #000 !important;
   }
 }
+
+figure figcaption {
+  text-align: center;
+  font-size: 12px;
+}

--- a/data/styles/Solarized (Light).css
+++ b/data/styles/Solarized (Light).css
@@ -197,3 +197,8 @@ kbd {
     color: #000 !important;
   }
 }
+
+figure figcaption {
+  text-align: center;
+  font-size: 12px;
+}

--- a/data/styles/markdown.css
+++ b/data/styles/markdown.css
@@ -105,3 +105,8 @@ body{font-size:16px;}
   p, h2, h3 { orphans: 3; widows: 3; }
   h2, h3 { page-break-after: avoid; }
 }
+
+figure figcaption {
+  text-align: center;
+  font-size: 12px;
+}

--- a/data/styles/screen.css
+++ b/data/styles/screen.css
@@ -100,3 +100,8 @@ pre code {
     float:left;
     margin: 10px;
 }
+
+figure figcaption {
+	text-align: center;
+	font-size: 12px;
+  }

--- a/data/styles/swiss.css
+++ b/data/styles/swiss.css
@@ -49,10 +49,10 @@ tr:nth-child(even) {
 
 body {
     font-family: Helvetica, Arial, Freesans, clean, sans-serif;
-padding:1em;
-margin:auto;
-max-width:42em;
-background:#fefefe;
+    padding:1em;
+    margin:auto;
+    max-width:42em;
+    background:#fefefe;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -130,3 +130,8 @@ a, a:visited {
     text-decoration: none;
 }
 
+
+figure figcaption {
+    text-align: center;
+    font-size: 12px;
+}

--- a/src/hoedown/html.c
+++ b/src/hoedown/html.c
@@ -406,8 +406,16 @@ rndr_image(hoedown_buffer *ob, const hoedown_buffer *link, const hoedown_buffer 
 		{
 			char * buffer = malloc(sizeof(char)*50);
 			memset(buffer,0, 50);
-			sprintf(buffer, "<b id=\"figure_%u\">Figure %u:</b> ", 
-					state->figure_counter, state->figure_counter);
+			if ((title && title->size) || (alt && alt->size))
+			{
+				sprintf(buffer, "<b id=\"figure_%u\">%s %u:</b> ", 
+						state->figure_counter, state->figure_tag, state->figure_counter);
+			}
+			else
+			{
+				sprintf(buffer, "<b id=\"figure_%u\">%s %u</b>", 
+						state->figure_counter, state->figure_tag, state->figure_counter);
+			}
 			hoedown_buffer_printf(ob, buffer, 50);
 			free(buffer);
 			state->figure_counter ++;
@@ -654,7 +662,7 @@ toc_finalize(hoedown_buffer *ob, int inline_render, const hoedown_renderer_data 
 }
 
 hoedown_renderer *
-hoedown_html_toc_renderer_new(int nesting_level)
+hoedown_html_toc_renderer_new(int nesting_level, char* figure_tag)
 {
 	static const hoedown_renderer cb_default = {
 		NULL,
@@ -708,6 +716,7 @@ hoedown_html_toc_renderer_new(int nesting_level)
 
 	state->toc_data.nesting_level = nesting_level;
 	state->figure_counter = 1;
+	state->figure_tag = figure_tag;
 
 	/* Prepare the renderer */
 	renderer = hoedown_malloc(sizeof(hoedown_renderer));
@@ -718,7 +727,7 @@ hoedown_html_toc_renderer_new(int nesting_level)
 }
 
 hoedown_renderer *
-hoedown_html_renderer_new(hoedown_html_flags render_flags, int nesting_level)
+hoedown_html_renderer_new(hoedown_html_flags render_flags, int nesting_level, char* figure_tag)
 {
 	static const hoedown_renderer cb_default = {
 		NULL,
@@ -772,6 +781,7 @@ hoedown_html_renderer_new(hoedown_html_flags render_flags, int nesting_level)
 
 	state->flags = render_flags;
 	state->figure_counter = 1;
+	state->figure_tag = figure_tag;
 	state->toc_data.nesting_level = nesting_level;
 
 	/* Prepare the renderer */

--- a/src/hoedown/html.h
+++ b/src/hoedown/html.h
@@ -20,7 +20,10 @@ typedef enum hoedown_html_flags {
 	HOEDOWN_HTML_ESCAPE = (1 << 1),
 	HOEDOWN_HTML_HARD_WRAP = (1 << 2),
 	HOEDOWN_HTML_USE_XHTML = (1 << 3),
-	HOEDOWN_HTML_MERMAID = (1 << 4) /* < experimental flag */
+	/* -- experimental flags -- */
+	HOEDOWN_HTML_MERMAID = (1 << 4),
+	HOEDOWN_HTML_FIGCAPTION = (1 << 5),
+	HOEDOWN_HTML_FIGCOUNTER = (1 << 6)
 } hoedown_html_flags;
 
 typedef enum hoedown_html_tag {
@@ -45,6 +48,7 @@ struct hoedown_html_renderer_state {
 	} toc_data;
 
 	hoedown_html_flags flags;
+	unsigned int figure_counter;
 
 	/* extra callbacks */
 	void (*link_attributes)(hoedown_buffer *ob, const hoedown_buffer *url, const hoedown_renderer_data *data);

--- a/src/hoedown/html.h
+++ b/src/hoedown/html.h
@@ -49,6 +49,7 @@ struct hoedown_html_renderer_state {
 
 	hoedown_html_flags flags;
 	unsigned int figure_counter;
+	char* figure_tag;
 
 	/* extra callbacks */
 	void (*link_attributes)(hoedown_buffer *ob, const hoedown_buffer *url, const hoedown_renderer_data *data);
@@ -70,12 +71,14 @@ hoedown_html_tag hoedown_html_is_tag(const uint8_t *data, size_t size, const cha
 /* hoedown_html_renderer_new: allocates a regular HTML renderer */
 hoedown_renderer *hoedown_html_renderer_new(
 	hoedown_html_flags render_flags,
-	int nesting_level
+	int nesting_level,
+	char* figure_tag
 ) __attribute__ ((malloc));
 
 /* hoedown_html_toc_renderer_new: like hoedown_html_renderer_new, but the returned renderer produces the Table of Contents */
 hoedown_renderer *hoedown_html_toc_renderer_new(
-	int nesting_level
+	int nesting_level,
+	char* figure_tag
 ) __attribute__ ((malloc));
 
 /* hoedown_html_renderer_free: deallocate an HTML renderer */

--- a/src/marker-markdown.c
+++ b/src/marker-markdown.c
@@ -142,6 +142,29 @@ html_footer(MarkerKaTeXMode     katex_mode,
   return buffer;
 }
 
+hoedown_html_flags 
+get_html_mode(MarkerMermaidMode mermaid_mode)
+{
+  hoedown_html_flags mode = 0;
+  
+  if (mermaid_mode != MERMAID_OFF)
+  {
+    mode |= HOEDOWN_HTML_MERMAID;
+  }
+
+  if (marker_prefs_get_use_figure_caption())
+  {
+    mode |= HOEDOWN_HTML_FIGCAPTION;
+  }
+
+  if (marker_prefs_get_use_figure_numbering())
+  {
+    mode |= HOEDOWN_HTML_FIGCOUNTER;
+  }
+
+  return mode;
+}
+
 
 char*
 marker_markdown_to_html(const char*         markdown,
@@ -156,8 +179,9 @@ marker_markdown_to_html(const char*         markdown,
   hoedown_renderer* renderer;
   hoedown_document* document;
   hoedown_buffer* buffer;
-   
-  renderer = hoedown_html_renderer_new(mermaid_mode == MERMAID_OFF ? 0 : HOEDOWN_HTML_MERMAID,0);
+  hoedown_html_flags html_mode = get_html_mode(mermaid_mode);
+
+  renderer = hoedown_html_renderer_new(html_mode, 0);
   
   document = hoedown_document_new(renderer,
                                   HOEDOWN_EXT_BLOCK         |
@@ -236,8 +260,9 @@ marker_markdown_to_html_with_css_inline(const char*         markdown,
   hoedown_renderer* renderer;
   hoedown_document* document;
   hoedown_buffer* buffer;
+  hoedown_html_flags html_mode = get_html_mode(mermaid_mode); 
 
-  renderer = hoedown_html_renderer_new(mermaid_mode == MERMAID_OFF ? 0 : HOEDOWN_HTML_MERMAID,0);
+  renderer = hoedown_html_renderer_new(html_mode, 0);
   
   document = hoedown_document_new(renderer,
                                   HOEDOWN_EXT_BLOCK         |

--- a/src/marker-markdown.c
+++ b/src/marker-markdown.c
@@ -181,7 +181,7 @@ marker_markdown_to_html(const char*         markdown,
   hoedown_buffer* buffer;
   hoedown_html_flags html_mode = get_html_mode(mermaid_mode);
 
-  renderer = hoedown_html_renderer_new(html_mode, 0);
+  renderer = hoedown_html_renderer_new(html_mode, 0, "Figure");
   
   document = hoedown_document_new(renderer,
                                   HOEDOWN_EXT_BLOCK         |
@@ -262,7 +262,7 @@ marker_markdown_to_html_with_css_inline(const char*         markdown,
   hoedown_buffer* buffer;
   hoedown_html_flags html_mode = get_html_mode(mermaid_mode); 
 
-  renderer = hoedown_html_renderer_new(html_mode, 0);
+  renderer = hoedown_html_renderer_new(html_mode, 0, "Figure");
   
   document = hoedown_document_new(renderer,
                                   HOEDOWN_EXT_BLOCK         |

--- a/src/marker-prefs.c
+++ b/src/marker-prefs.c
@@ -90,6 +90,30 @@ marker_prefs_set_use_mermaid(gboolean state)
 }
 
 gboolean
+marker_prefs_get_use_figure_caption()
+{
+  return g_settings_get_boolean(prefs.preview_settings, "figure-caption-toggle");
+}
+
+void
+marker_prefs_set_use_figure_caption(gboolean state)
+{
+  g_settings_set_boolean(prefs.preview_settings, "figure-caption-toggle", state);
+}
+
+gboolean
+marker_prefs_get_use_figure_numbering()
+{
+  return g_settings_get_boolean(prefs.preview_settings, "figure-numbering-toggle");
+}
+
+void
+marker_prefs_set_use_figure_numbering(gboolean state)
+{
+  g_settings_set_boolean(prefs.preview_settings, "figure-numbering-toggle", state);
+}
+
+gboolean
 marker_prefs_get_use_highlight()
 {
   return g_settings_get_boolean(prefs.preview_settings, "highlight-toggle");
@@ -449,6 +473,25 @@ enable_mermaid_toggled(GtkToggleButton* button,
 }
 
 static void
+figure_caption_toggled(GtkToggleButton* button,
+                       gpointer         user_data)
+{
+  gboolean state = gtk_toggle_button_get_active(button);
+  gtk_widget_set_sensitive(GTK_WIDGET(user_data), state);
+  marker_prefs_set_use_figure_caption(state);
+  refresh_preview();
+}
+
+static void
+figure_numbering_toggled(GtkToggleButton* button,
+                       gpointer         user_data)
+{
+  gboolean state = gtk_toggle_button_get_active(button);
+  marker_prefs_set_use_figure_numbering(state);
+  refresh_preview();
+}
+
+static void
 wrap_text_toggled(GtkToggleButton* button,
                   gpointer         user_data)
 {
@@ -779,6 +822,15 @@ marker_prefs_show_window()
     GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "mermaid_check_button"));
   gtk_toggle_button_set_active(check_button, marker_prefs_get_use_mermaid());
 
+  check_button =
+    GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "figure_caption_check_button"));
+  gtk_toggle_button_set_active(check_button, marker_prefs_get_use_figure_caption());
+
+  check_button =
+    GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "figure_numbering_check_button"));
+  gtk_toggle_button_set_active(check_button, marker_prefs_get_use_figure_numbering());
+  gtk_widget_set_sensitive(GTK_WIDGET(check_button), marker_prefs_get_use_figure_caption());
+
   check_button = 
     GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "code_highlight_check_button"));
   gtk_toggle_button_set_active(check_button, marker_prefs_get_use_highlight());
@@ -884,6 +936,12 @@ marker_prefs_show_window()
   gtk_builder_add_callback_symbol(builder,
                                   "enable_mermaid_toggled",
                                   G_CALLBACK(enable_mermaid_toggled));
+  gtk_builder_add_callback_symbol(builder,
+                                  "figure_caption_toggled",
+                                  G_CALLBACK(figure_caption_toggled));
+  gtk_builder_add_callback_symbol(builder,
+                                  "figure_numbering_toggled",
+                                  G_CALLBACK(figure_numbering_toggled));
   gtk_builder_add_callback_symbol(builder,
                                   "wrap_text_toggled", 
                                   G_CALLBACK(wrap_text_toggled));

--- a/src/marker-prefs.h
+++ b/src/marker-prefs.h
@@ -112,6 +112,24 @@ void
 marker_prefs_set_use_highlight(gboolean state);
 
 gboolean
+marker_prefs_get_use_mermaid();
+
+void
+marker_prefs_set_use_mermaid(gboolean state);
+
+gboolean
+marker_prefs_get_use_figure_caption();
+
+void
+marker_prefs_set_use_figure_caption(gboolean state);
+
+gboolean
+marker_prefs_get_use_figure_numbering();
+
+void
+marker_prefs_set_use_figure_numbering(gboolean state);
+
+gboolean
 marker_prefs_get_gnome_appmenu();
 
 void

--- a/src/resources/ui/prefs-window.ui
+++ b/src/resources/ui/prefs-window.ui
@@ -438,6 +438,47 @@
                 <property name="position">3</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkCheckButton" id="figure_caption_check_button">
+                    <property name="label" translatable="yes">Enable figure caption</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="figure_caption_toggled" object="figure_numbering_check_button" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="figure_numbering_check_button">
+                    <property name="label" translatable="yes">Enable figure numbering</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="figure_numbering_toggled" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="position">1</property>


### PR DESCRIPTION
I added a small feature to hoedown to display the title or the alt text of an image as caption:
```markdown
Image with title:
![alt text](path/to/image "title")

Image with only alt text:
![alt text](path/to/image)
```
Moreover I added the option to numbering the figure (and use the number as id of the html block).

![figure_captioning_num](https://user-images.githubusercontent.com/276686/34726394-2a07cb3e-f554-11e7-9599-72922733be60.png)
**Figure caption and numbering enabled**

![figure_caption](https://user-images.githubusercontent.com/276686/34726412-3a93694a-f554-11e7-90ae-b5e343419ebb.png)
**Figure caption enabled, numbering disabled**

![figure_no_caption](https://user-images.githubusercontent.com/276686/34726443-53f3c2a4-f554-11e7-9d4c-80d13b23c81a.png)
**Figure caption and numbering disabled**

To nicely render the caption I modified some (or all?) css theme to align the figure caption to the centre and use a smaller font. 
