### PR TITLE
Equation numbering (sequential to #84)

### DIFF
--- a/data/com.github.fabiocolacio.marker.gschema.xml
+++ b/data/com.github.fabiocolacio.marker.gschema.xml
@@ -133,6 +133,11 @@
       <summary>Enable figure numbering in Preview</summary>
       <description>Enable and display figure numbering in the live preview (when figure-caption-toggle is enabled).</description>
     </key>
+    <key name="equation-numbering-toggle" type="b">
+      <default>false</default>
+      <summary>Enable numbering of equation in Preview</summary>
+      <description>Enable automatic numbering of equations in the live preview.</description>
+    </key>
   </schema>
   
   <schema path="/com/github/fabiocolacio/marker/preferences/window/" id="com.github.fabiocolacio.marker.preferences.window">

--- a/src/hoedown/html.c
+++ b/src/hoedown/html.c
@@ -404,13 +404,13 @@ rndr_image(hoedown_buffer *ob, const hoedown_buffer *link, const hoedown_buffer 
 		HOEDOWN_BUFPUTSL(ob, "<figcaption>");
 		if ((state->flags & HOEDOWN_HTML_FIGCOUNTER) != 0)
 		{
+			state->figure_counter ++;
 			char * buffer = malloc(sizeof(char)*50);
 			memset(buffer,0, 50);
 			sprintf(buffer, "<b id=\"figure_%u\">Figure %u:</b> ", 
 					state->figure_counter, state->figure_counter);
 			hoedown_buffer_printf(ob, buffer, 50);
 			free(buffer);
-			state->figure_counter ++;
 		}
 		if (title && title->size)
 		{
@@ -587,8 +587,23 @@ rndr_footnote_ref(hoedown_buffer *ob, unsigned int num, const hoedown_renderer_d
 static int
 rndr_math(hoedown_buffer *ob, const hoedown_buffer *text, int displaymode, const hoedown_renderer_data *data)
 {
+	hoedown_html_renderer_state *state = data->opaque;
+
 	hoedown_buffer_put(ob, (const uint8_t *)(displaymode ? "\\[" : "\\("), 2);
+	if (displaymode && (state->flags & HOEDOWN_HTML_EQCOUNTER) !=0)
+	{
+		HOEDOWN_BUFPUTSL(ob, "\\begin{array}{lr}");
+	}
 	escape_html(ob, text->data, text->size);
+	if (displaymode && (state->flags & HOEDOWN_HTML_EQCOUNTER) !=0)
+	{
+		state->equation_counter ++;
+		char * buffer = malloc(sizeof(char)*30);
+		memset(buffer, 0, 30); /*\begin{array}{lr} & \quad(1)\\\end{array}*/
+		sprintf(buffer, "& \\quad(%u)\\end{array}", state->equation_counter);
+		hoedown_buffer_printf(ob, buffer, 30);
+		free(buffer);
+	}
 	hoedown_buffer_put(ob, (const uint8_t *)(displaymode ? "\\]" : "\\)"), 2);
 	return 1;
 }
@@ -707,7 +722,8 @@ hoedown_html_toc_renderer_new(int nesting_level)
 	memset(state, 0x0, sizeof(hoedown_html_renderer_state));
 
 	state->toc_data.nesting_level = nesting_level;
-	state->figure_counter = 1;
+	state->figure_counter = 0;
+	state->equation_counter = 0;
 
 	/* Prepare the renderer */
 	renderer = hoedown_malloc(sizeof(hoedown_renderer));
@@ -771,7 +787,8 @@ hoedown_html_renderer_new(hoedown_html_flags render_flags, int nesting_level)
 	memset(state, 0x0, sizeof(hoedown_html_renderer_state));
 
 	state->flags = render_flags;
-	state->figure_counter = 1;
+	state->figure_counter = 0;
+	state->equation_counter = 0;
 	state->toc_data.nesting_level = nesting_level;
 
 	/* Prepare the renderer */

--- a/src/hoedown/html.h
+++ b/src/hoedown/html.h
@@ -23,7 +23,8 @@ typedef enum hoedown_html_flags {
 	/* -- experimental flags -- */
 	HOEDOWN_HTML_MERMAID = (1 << 4),
 	HOEDOWN_HTML_FIGCAPTION = (1 << 5),
-	HOEDOWN_HTML_FIGCOUNTER = (1 << 6)
+	HOEDOWN_HTML_FIGCOUNTER = (1 << 6),
+	HOEDOWN_HTML_EQCOUNTER = (1 << 7)
 } hoedown_html_flags;
 
 typedef enum hoedown_html_tag {
@@ -49,6 +50,7 @@ struct hoedown_html_renderer_state {
 
 	hoedown_html_flags flags;
 	unsigned int figure_counter;
+	unsigned int equation_counter;
 
 	/* extra callbacks */
 	void (*link_attributes)(hoedown_buffer *ob, const hoedown_buffer *url, const hoedown_renderer_data *data);

--- a/src/marker-markdown.c
+++ b/src/marker-markdown.c
@@ -162,6 +162,11 @@ get_html_mode(MarkerMermaidMode mermaid_mode)
     mode |= HOEDOWN_HTML_FIGCOUNTER;
   }
 
+  if (marker_prefs_get_use_katex() && marker_prefs_get_use_equation_numbering())
+  {
+    mode |= HOEDOWN_HTML_EQCOUNTER;
+  }
+
   return mode;
 }
 

--- a/src/marker-prefs.c
+++ b/src/marker-prefs.c
@@ -76,6 +76,17 @@ marker_prefs_set_use_katex(gboolean state)
   g_settings_set_boolean(prefs.preview_settings, "katex-toggle", state);
 }
 
+gboolean
+marker_prefs_get_use_equation_numbering()
+{
+  return g_settings_get_boolean(prefs.preview_settings, "equation-numbering-toggle");
+}
+
+void
+marker_prefs_set_use_equation_numbering(gboolean state)
+{
+  g_settings_set_boolean(prefs.preview_settings, "equation-numbering-toggle", state);
+}
 
 gboolean
 marker_prefs_get_use_mermaid()
@@ -460,6 +471,16 @@ enable_katex_toggled(GtkToggleButton* button,
 {
   gboolean state = gtk_toggle_button_get_active(button);
   marker_prefs_set_use_katex(state);
+  gtk_widget_set_sensitive(GTK_WIDGET(user_data), state);
+  refresh_preview();
+}
+
+static void
+equation_numbering_toggled(GtkToggleButton* button,
+                       gpointer         user_data)
+{
+  gboolean state = gtk_toggle_button_get_active(button);
+  marker_prefs_set_use_equation_numbering(state);
   refresh_preview();
 }
 
@@ -819,6 +840,11 @@ marker_prefs_show_window()
   gtk_toggle_button_set_active(check_button, marker_prefs_get_use_katex());
 
   check_button =
+    GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "equation_numbering_check_button"));
+  gtk_toggle_button_set_active(check_button, marker_prefs_get_use_equation_numbering());
+  gtk_widget_set_sensitive(GTK_WIDGET(check_button), marker_prefs_get_use_katex());
+
+  check_button =
     GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "mermaid_check_button"));
   gtk_toggle_button_set_active(check_button, marker_prefs_get_use_mermaid());
 
@@ -933,6 +959,9 @@ marker_prefs_show_window()
   gtk_builder_add_callback_symbol(builder,
                                   "enable_katex_toggled",
                                   G_CALLBACK(enable_katex_toggled));
+  gtk_builder_add_callback_symbol(builder,
+                                  "equation_numbering_toggled",
+                                  G_CALLBACK(equation_numbering_toggled));
   gtk_builder_add_callback_symbol(builder,
                                   "enable_mermaid_toggled",
                                   G_CALLBACK(enable_mermaid_toggled));

--- a/src/marker-prefs.h
+++ b/src/marker-prefs.h
@@ -106,6 +106,12 @@ void
 marker_prefs_set_use_katex(gboolean state);
 
 gboolean
+marker_prefs_get_use_equation_numbering();
+
+void
+marker_prefs_set_use_equation_numbering(gboolean state);
+
+gboolean
 marker_prefs_get_use_highlight();
 
 void

--- a/src/resources/ui/prefs-window.ui
+++ b/src/resources/ui/prefs-window.ui
@@ -409,13 +409,39 @@
               </packing>
             </child>
             <child>
-              <object class="GtkCheckButton" id="katex_check_button">
-                <property name="label" translatable="yes">Enable KaTeX</property>
+              <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
-                <signal name="toggled" handler="enable_katex_toggled" swapped="no"/>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkCheckButton" id="katex_check_button">
+                    <property name="label" translatable="yes">Enable KaTeX</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="enable_katex_toggled" object="equation_numbering_check_button" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="equation_numbering_check_button">
+                    <property name="label" translatable="yes">Enable equation numbering</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="equation_numbering_toggled" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
An addition extension to hoedown after #84  is to add a simple equation counter in the equation block:
![marker_numbered_equation](https://user-images.githubusercontent.com/276686/34729286-912eb518-f55c-11e7-94a8-84e58992f8c6.png)

There is a check button in the preferences and by default is disabled.
