### PR TITLE
Sketcher

### DIFF
--- a/src/marker-editor-window.c
+++ b/src/marker-editor-window.c
@@ -51,6 +51,7 @@ struct _MarkerEditorWindow
   MarkerSourceView           *source_view;
   GtkWidget                  *source_scroll;
   MarkerPreview              *web_view;
+  MarkerSketcherWindow       *sketcher;
   GtkBox                     *vbox;
   
   GFile                      *file;
@@ -700,9 +701,9 @@ preview_zoom_changed_cb (MarkerPreview *preview,
 void
 sketch_cb(gpointer       user_data)
 {
-  MarkerEditorWindow * w = MARKER_EDITOR_WINDOW(user_data);
   
-  marker_sketcher_window_show(gtk_window_get_application(GTK_WINDOW(user_data)), w->file, w->source_view);
+  MarkerEditorWindow * w = MARKER_EDITOR_WINDOW(user_data);
+  w->sketcher = marker_sketcher_window_show(GTK_WINDOW(user_data), w->file, w->source_view);
 }
 
          
@@ -809,6 +810,7 @@ static void
 init_ui (MarkerEditorWindow *window)
 {
   window->triggered = FALSE;
+  window->sketcher = NULL;
   GtkBuilder* builder =
     gtk_builder_new_from_resource("/com/github/fabiocolacio/marker/ui/editor-window.ui");
 

--- a/src/marker-editor-window.c
+++ b/src/marker-editor-window.c
@@ -696,6 +696,16 @@ preview_zoom_changed_cb (MarkerPreview *preview,
   g_free (zoom_level_str);
 }
          
+         
+void
+sketch_cb(gpointer       user_data)
+{
+  MarkerEditorWindow * w = MARKER_EDITOR_WINDOW(user_data);
+  
+  marker_sketcher_window_show(gtk_window_get_application(GTK_WINDOW(user_data)), w->file, w->source_view);
+}
+
+         
 static gboolean
 key_pressed(GtkWidget   *widget,
             GdkEventKey *event,
@@ -758,7 +768,11 @@ key_pressed(GtkWidget   *widget,
       case GDK_KEY_w:
         marker_editor_window_try_close (window);
         break;
-      
+        
+      case GDK_KEY_k:  
+        sketch_cb(window);
+        break;
+        
       case GDK_KEY_q:
         marker_quit ();
         break;
@@ -790,16 +804,6 @@ marker_editor_window_get_preview(MarkerEditorWindow* window)
   return window->web_view;
 }
 
-
-void
-sketch_cb(GSimpleAction* action,
-                   GVariant*      parameter,
-                   gpointer       user_data)
-{
-  MarkerEditorWindow * w = MARKER_EDITOR_WINDOW(user_data);
-  
-  marker_sketcher_window_show(gtk_window_get_application(GTK_WINDOW(user_data)), w->file, w->source_view);
-}
 
 static void
 init_ui (MarkerEditorWindow *window)
@@ -918,7 +922,6 @@ init_ui (MarkerEditorWindow *window)
   
   gtk_builder_add_callback_symbol(builder, "open_cb", G_CALLBACK(open_cb));
   gtk_builder_add_callback_symbol(builder, "save_cb", G_CALLBACK(save_cb));
-  gtk_builder_add_callback_symbol(builder, "sketch_cb", G_CALLBACK(sketch_cb));
   gtk_builder_connect_signals(builder, window);
   
   g_object_unref(builder);

--- a/src/marker-sketcher-window.c
+++ b/src/marker-sketcher-window.c
@@ -95,7 +95,7 @@ configure_event_cb (GtkWidget         *widget,
     cairo_surface_destroy (w->surface);
 
   w->surface = gdk_window_create_similar_surface (gtk_widget_get_window(widget),
-                                                  CAIRO_CONTENT_COLOR,
+                                                  CAIRO_CONTENT_COLOR_ALPHA,
                                                   gtk_widget_get_allocated_width (widget),
                                                   gtk_widget_get_allocated_height (widget));
   clear_surface (w->surface);
@@ -156,8 +156,11 @@ draw_brush (GtkWidget *widget,
   }
   
   cairo_t *cr;
-
   cr = cairo_create (w->surface);
+  if (w->tool == PEN)
+    cairo_set_source_rgba(cr, w->color.red, w->color.green, w->color.blue, w->color.alpha);
+  else if (w->tool == ERASER)
+    cairo_set_source_rgb(cr, 1, 1, 1);
   if (!w->status)
   {
 
@@ -169,10 +172,7 @@ draw_brush (GtkWidget *widget,
   } else
   {
     cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-    if (w->tool == PEN)
-      cairo_set_source_rgb(cr, w->color.red, w->color.green, w->color.blue);
-    else if (w->tool == ERASER)
-      cairo_set_source_rgb(cr, 1, 1, 1);
+
     cairo_set_line_width(cr, w->size);
     cairo_move_to(cr, w->pos_x, w->pos_y);
     cairo_line_to(cr, x, y);
@@ -195,7 +195,7 @@ add_history(MarkerSketcherWindow * w)
 {
   GtkWidget * widget = GTK_WIDGET(w->drawing_area);
   cairo_surface_t * destination = cairo_surface_create_similar(w->surface, 
-                                                               CAIRO_CONTENT_COLOR,
+                                                               CAIRO_CONTENT_COLOR_ALPHA,
                                                                gtk_widget_get_allocated_width (widget),
                                                                gtk_widget_get_allocated_height (widget ));
   cairo_t *cr = cairo_create (destination);
@@ -454,6 +454,7 @@ add_text_cb(GtkWidget *button,
   gtk_popover_popdown(w->text_popover);
   add_history(w);
   draw_text(w);
+  gtk_entry_set_text(w->text_entry,"");
 }
 
 static void
@@ -462,6 +463,7 @@ close_text_cb(GtkButton *button,
 {
   MarkerSketcherWindow * w = MARKER_SKETCHER_WINDOW(user_data);
   gtk_popover_popdown(w->text_popover);
+  gtk_entry_set_text(w->text_entry,"");
 }
 
 static void

--- a/src/marker-sketcher-window.c
+++ b/src/marker-sketcher-window.c
@@ -92,13 +92,26 @@ configure_event_cb (GtkWidget         *widget,
 {
   MarkerSketcherWindow * w = MARKER_SKETCHER_WINDOW(data);
   if (w->surface)
-    cairo_surface_destroy (w->surface);
-
-  w->surface = gdk_window_create_similar_surface (gtk_widget_get_window(widget),
-                                                  CAIRO_CONTENT_COLOR_ALPHA,
-                                                  gtk_widget_get_allocated_width (widget),
-                                                  gtk_widget_get_allocated_height (widget));
-  clear_surface (w->surface);
+  {
+    cairo_surface_t * destination = gdk_window_create_similar_surface (gtk_widget_get_window(widget),
+                                                                        CAIRO_CONTENT_COLOR_ALPHA,
+                                                                        gtk_widget_get_allocated_width (widget),
+                                                                        gtk_widget_get_allocated_height (widget));
+    clear_surface(destination);
+    cairo_t *cr = cairo_create (destination);
+    cairo_set_source_surface (cr, w->surface, 0, 0);
+    cairo_paint (cr);
+    cairo_surface_destroy(w->surface);
+    w->surface = destination;
+  }
+  else{
+    w->surface = gdk_window_create_similar_surface (gtk_widget_get_window(widget),
+                                                    CAIRO_CONTENT_COLOR_ALPHA,
+                                                    gtk_widget_get_allocated_width (widget),
+                                                    gtk_widget_get_allocated_height (widget));
+  
+    clear_surface (w->surface);
+  }
   return TRUE;
 }
 
@@ -475,8 +488,9 @@ init_ui (MarkerSketcherWindow * window)
   
   GtkDrawingArea * drawing_area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   window->drawing_area = drawing_area;
-  gtk_widget_set_size_request(GTK_WIDGET(drawing_area), 800, 600);
 
+  gtk_window_set_default_size(GTK_WINDOW(window), 800, 600);
+  
   GtkBox * vbox = GTK_BOX(gtk_builder_get_object(builder, "vbox"));
   gtk_box_pack_start(vbox, GTK_WIDGET(drawing_area),TRUE,TRUE, 5);
 

--- a/src/marker-sketcher-window.h
+++ b/src/marker-sketcher-window.h
@@ -41,7 +41,7 @@ G_DECLARE_FINAL_TYPE (MarkerSketcherWindow, marker_sketcher_window, MARKER, SKET
 MarkerSketcherWindow*  
 marker_sketcher_window_new (GtkApplication * application);
 
-void
-marker_sketcher_window_show(GtkApplication * app, GFile * file, MarkerSourceView * source_view);
+MarkerSketcherWindow*  
+marker_sketcher_window_show(GtkWindow* parent, GFile * file, MarkerSourceView * source_view);
 
 #endif

--- a/src/resources/ui/shortcuts-window.ui
+++ b/src/resources/ui/shortcuts-window.ui
@@ -74,6 +74,13 @@
                 <property name="title" context="shortcut window">Make selection monospace</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
+                <property name="accelerator">&lt;ctrl&gt;k</property>
+                <property name="title" context="shortcut window">Insert sketch</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/src/resources/ui/sketcher-window.ui
+++ b/src/resources/ui/sketcher-window.ui
@@ -5,22 +5,22 @@
   <object class="GtkImage" id="add_img">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">dialog-ok</property>
+    <property name="icon_name">insert-image-symbolic.symbolic</property>
   </object>
   <object class="GtkImage" id="add_text_img">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">dialog-ok</property>
+    <property name="icon_name">insert-text-symbolic.symbolic</property>
   </object>
   <object class="GtkImage" id="close_img">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">dialog-close</property>
+    <property name="icon_name">window-close-symbolic.symbolic</property>
   </object>
   <object class="GtkImage" id="close_text_img">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">dialog-close</property>
+    <property name="icon_name">window-close-symbolic.symbolic</property>
   </object>
   <object class="GtkPopover" id="text_popover">
     <property name="can_focus">False</property>
@@ -52,7 +52,7 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="pack_type">end</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -66,7 +66,8 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <style>
@@ -257,7 +258,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -271,7 +272,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <style>


### PR DESCRIPTION
First version of the sketcher #105  implements the following tools and options:

 - Tools: Pen/Eraser/Text
 - RGBA Color Chooser
 - SIzes: Small/Medium/Large
 - History: unlimited undo and redo (ctrl+z/ctrl+shift+z)

It is displayed using the short cut "ctrl+k" from the editor and it automatically add the image to the current position of the source view.

![sketcher](https://user-images.githubusercontent.com/276686/35047840-88a89694-fb9b-11e7-9355-fc4d6eceb55e.png)

