### PR TITLE
Minor appdata fixes for Flathub

### DIFF
--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -11,7 +11,7 @@
     <p>Features:</p>
     <ul>
       <li>View and edit markdown documents</li>
-      <li>Covert markdown documents to HTML</li>
+      <li>Convert markdown documents to HTML</li>
       <li>Tex math rendering</li>
       <li>Support for mermaid diagrams</li>
       <li>Support for charter plots</li>

--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -1,27 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2013 First Lastname <your@email.com> -->
+<!-- Copyright 2018 Fabio Colacio <fabio.colacio.dev@gmail.com> -->
 <component type="desktop-application">
   <id>com.github.fabiocolacio.marker</id>
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>Marker</name>
-  <summary>The Markdown Editor</summary>
+  <summary>Powerful markdown editor</summary>
 
   <description>
-    <p>
-      Markdown is a powerful Markdown editor for Gnome.
-    </p>
-    <p>Features list:</p>
+    <p>Features:</p>
     <ul>
       <li>View and edit markdown documents</li>
-      <li>HTML conversion of markdown documents</li>
+      <li>Covert markdown documents to HTML</li>
       <li>Tex math rendering</li>
-      <!--NEED FIX <li>Support for <a href="https://mermaidjs.github.io/">mermaid</a> diagrams</li>
-      <li>Support for <a href="https://github.com/Mandarancio/charter">charter</a> plots</li>
-      -->
+      <li>Support for mermaid diagrams</li>
+      <li>Support for charter plots</li>
       <li>Syntax highlighting for code blocks</li>
       <li>Integrated sketch editor</li>
-      <li>Flexible export options
+      <li>Exports to
         <ul>
           <li>PDF</li>
           <li>RTF</li>
@@ -63,7 +59,7 @@
   <releases>
     <release version="2018.01.23" date="2018-01-23">
       <description>
-        <p>First release for flathub.</p>
+        <p>Initial Flathub release</p>
       </description>
     </release>
   </releases>


### PR DESCRIPTION
Fixes some minor things in the appdata file (added missing developer name and email address, removed hyperlinks).

It now passes validate-relax, which should be enough to get it published. There are still some non-critical issues, like the size of the screenshots, but that can be addressed later.

#122