### PR TITLE
Fix flatpak visibility in software stores

### DIFF
--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2018 Fabio Colacio <fabio.colacio.dev@gmail.com> -->
 <component type="desktop-application">
-  <id>com.github.fabiocolacio.marker</id>
+  <id>com.github.fabiocolacio.marker.desktop</id>
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>Marker</name>
@@ -54,6 +54,7 @@
 
   <provides>
     <binary>marker</binary>
+    <id>com.github.fabiocolacio.marker</id>
   </provides>
 
   <releases>

--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -64,4 +64,35 @@
       </description>
     </release>
   </releases>
+
+ <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+  
 </component>


### PR DESCRIPTION
Until this [upstream commit](https://github.com/flatpak/flatpak/commit/6ab657b9100427f3c4c0f19f8695b7b71a417f49) flatpak wouldn't export appdata from any app that didn't end it's appdata ID with .desktop. This would prevent your app from showing up in software stores or any other UIs for Flathub.

This commit changes the app ID but makes sure that the appdata file still provides the old ID to cover any existing command line installs.

The second commit adds OARS metadata, which flatpak encourages and makes sure your app is correctly categorised.

This has been [patched in Flathub ](https://github.com/flathub/com.github.fabiocolacio.marker/pull/1)as it's the only way to get the app to show up correctly until clients are updated.