### PR TITLE
don't run post-install.sh when creating distro packages

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -3,11 +3,15 @@
 prefix=${MESON_INSTALL_PREFIX}
 datadir=$prefix"/share"
 
-echo "Compiling GSchema..."
-glib-compile-schemas $datadir"/glib-2.0/schemas"
+# Distro packagers define DESTDIR and they don't
+# want/need us to do the below
+if [ -z $DESTDIR ]; then
+    echo "Compiling GSchema..."
+    glib-compile-schemas $datadir"/glib-2.0/schemas"
 
-echo "Updating icon cache..."
-gtk-update-icon-cache -f -t $datadir"/icons/hicolor"
+    echo "Updating icon cache..."
+    gtk-update-icon-cache -f -t $datadir"/icons/hicolor"
 
-echo "Updating desktop database..."
-update-desktop-database -q $datadir"/applications"
+    echo "Updating desktop database..."
+    update-desktop-database -q $datadir"/applications"
+fi


### PR DESCRIPTION
Basically distros want to compile gschemas and update the icon cache themselves and not have it done via a post-install script