### PR TITLE
The Appdata files now go to /usr/share/metainfo

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ COMMON_DIR = join_paths(APP_DIR, 'common')
 SCRIPTS_DIR = join_paths(APP_DIR, 'scripts')
 HIGHLIGHT_STYLES_DIR = join_paths(join_paths(SCRIPTS_DIR, 'highlight'),'styles')
 WEB_EXTENSIONS_DIRECTORY = join_paths(APP_DIR, 'extensions')
-APPDATA_DIR = join_paths(DATA_DIR, 'appdata')
+APPDATA_DIR = join_paths(DATA_DIR, 'metainfo')
 LOCALE_DIR = join_paths(PREFIX, get_option('localedir'))
 
 EXECUTABLE_NAME = 'marker'


### PR DESCRIPTION
Tiny change. From
  `/usr/share/appdata/%{id}.appdata.xml`
to
 `/usr/share/metainfo/%{id}.appdata.xml`

https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps