### PR TITLE
Fix Flathub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Marker is a markdown editor for linux made with Gtk+-3.0
 ## Packages
 
 * [Fedora (thanks to @tim77)](https://copr.fedorainfracloud.org/coprs/atim/marker/)
-* [Flathub (thanks to @jsparber and @bertob)](https://beta.flathub.org/apps/details/com.github.fabiocolacio.marker)
+* [Flathub (thanks to @jsparber and @bertob)](https://flathub.org/apps/details/com.github.fabiocolacio.marker)
 * [Arch Linux (thanks to @mmetak)](https://aur.archlinux.org/packages/marker-git/)
 
 ## Installation From Source

--- a/docs/index.html
+++ b/docs/index.html
@@ -120,7 +120,7 @@ body{font-size:16px;}
 figure figcaption {
   text-align: center;
   font-size: 12px;
-}ÿ×ÙÙÿ±X
+}Ã¿Ã—Ã™Ã™Ã¿Â±X
 </style>
 </head>
 <body>
@@ -159,7 +159,7 @@ to documents.</li>
 
 <h2>Get Marker</h2>
 
-<p>Install Marker on <a href="https://beta.flathub.org/apps/details/com.github.fabiocolacio.marker">FlatHub</a>!</p>
+<p>Install Marker on <a href="https://flathub.org/apps/details/com.github.fabiocolacio.marker">FlatHub</a>!</p>
 
 <p>Marker is also available in the <a href="https://aur.archlinux.org/packages/marker-git/">Arch User Repositories</a>.</p>
 


### PR DESCRIPTION
The Flathub links still point to [beta.flathub.org](https://beta.flathub.org/) which does not exist any more. They should point to the respective page on [flathub.org](https://flathub.org/) instead.

This also resolves #270.