### PR TITLE
Remove .htaccess file

### DIFF
--- a/data/scripts/mathjax/extensions/a11y/mathmaps/.htaccess
+++ b/data/scripts/mathjax/extensions/a11y/mathmaps/.htaccess
@@ -1,3 +1,0 @@
-Header add Access-Control-Allow-Origin "*"
-Header add Access-Control-Allow-Headers "origin, x-requested-with, content-type"
-Header add Access-Control-Allow-Methods "PUT, GET, POST, DELETE, OPTIONS"


### PR DESCRIPTION
Can we safely delete this file?
`scripts/mathjax/extensions/a11y/mathmaps/.htaccess`

PS: some linters consider this an error
`E: htaccess-file /usr/share/com.github.fabiocolacio.marker/scripts/mathjax/extensions/a11y/mathmaps/.htaccess`