### PR TITLE
Remember window size

### DIFF
--- a/src/marker-prefs.c
+++ b/src/marker-prefs.c
@@ -48,6 +48,30 @@ marker_prefs_set_use_dark_theme(gboolean state)
   g_settings_set_boolean(prefs.window_settings, "enable-dark-mode", state);
 }
 
+guint
+marker_prefs_get_window_width()
+{
+  return g_settings_get_uint(prefs.window_settings, "window-width");
+}
+
+void
+marker_prefs_set_window_width(guint width)
+{
+  g_settings_set_uint(prefs.window_settings, "window-width", width);
+}
+
+guint
+marker_prefs_get_window_height()
+{
+  return g_settings_get_uint(prefs.window_settings, "window-height");
+}
+
+void
+marker_prefs_set_window_height(guint height)
+{
+  g_settings_set_uint(prefs.window_settings, "window-height", height);
+}
+
 gboolean
 marker_prefs_get_use_syntax_theme()
 {

--- a/src/marker-prefs.h
+++ b/src/marker-prefs.h
@@ -32,6 +32,10 @@ typedef struct {
 
 gboolean             marker_prefs_get_use_dark_theme             (void);
 void                 marker_prefs_set_use_dark_theme             (gboolean            state);
+guint                marker_prefs_get_window_width               (void);
+void                 marker_prefs_set_window_width               (guint               width);
+guint                marker_prefs_get_window_height              (void);
+void                 marker_prefs_set_window_height              (guint               height);
 char                *marker_prefs_get_syntax_theme               (void);
 void                 marker_prefs_set_syntax_theme               (const char         *theme);
 gboolean             marker_prefs_get_use_syntax_theme           (void);

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -831,10 +831,12 @@ marker_window_init (MarkerWindow *window)
   marker_window_hide_sidebar (window);
   guint width = marker_prefs_get_window_width();
   guint height = marker_prefs_get_window_height();
-  if (width == 0) {
+  if (width == 0)
+  {
     marker_prefs_set_window_width(900);
   }
-  if (height == 0) {
+  if (height == 0)
+  {
     marker_prefs_set_window_height(600);
   }
   gtk_window_set_default_size(GTK_WINDOW(window), width, height);

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -829,7 +829,15 @@ marker_window_init (MarkerWindow *window)
 
   /** Window **/
   marker_window_hide_sidebar (window);
-  gtk_window_set_default_size(GTK_WINDOW(window), 900, 600);
+  guint width = marker_prefs_get_window_width();
+  guint height = marker_prefs_get_window_height();
+  if (width == 0) {
+    marker_prefs_set_window_width(900);
+  }
+  if (height == 0) {
+    marker_prefs_set_window_height(600);
+  }
+  gtk_window_set_default_size(GTK_WINDOW(window), width, height);
   gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER);
   g_signal_connect(window, "delete-event", G_CALLBACK(window_deleted_event_cb), window);
 


### PR DESCRIPTION
This is an attempt at solving a part of #309.

I am currently lost at this error that occurs when I try to run `./marker`:
```
(marker:29491): GLib-GIO-ERROR **: 13:42:20.106: Settings schema 'com.github.fabiocolacio.marker.preferences.window' does
not contain a key named 'window-width'
[1]    29491 trace trap  ./marker
```

It appears to have a simple fix, but I don't know where I missed adding the initialization of that configuration.