### PR TITLE
Avoid double free corruption

### DIFF
--- a/src/marker-exporter.c
+++ b/src/marker-exporter.c
@@ -93,7 +93,6 @@ marker_exporter_export_pandoc(const char*        markdown,
         system(command);
       }
 
-      free(command);
       remove(ftmp);
     }
   }


### PR DESCRIPTION
Having this free() command I get frequent crashes after an export. Exporting multiple times usually leads to crash.