### PR TITLE
Quote paths in pandoc command

### DIFF
--- a/src/marker-exporter.c
+++ b/src/marker-exporter.c
@@ -83,7 +83,7 @@ marker_exporter_export_pandoc(const char*        markdown,
       char* command = NULL;
 
       asprintf(&command,
-               "pandoc -s -c %s -o %s %s",
+               "pandoc -s -c \"%s\" -o \"%s\" \"%s\"",
                stylesheet_path,
                outfile,
                ftmp);


### PR DESCRIPTION
Quoting is necesary if path has unconvenient characters like spaces.
Fixes #363 