### PR TITLE
Update Flathub Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Marker is a markdown editor for linux made with GTK+-3.0
 ## Packages
 
 * [Fedora (thanks to @tim77)](https://src.fedoraproject.org/rpms/marker)
-* [Flathub (thanks to @jsparber and @bertob)](https://beta.flathub.org/apps/details/com.github.fabiocolacio.marker)
+* [Flathub (thanks to @jsparber and @bertob)](https://flathub.org/apps/details/com.github.fabiocolacio.marker)
 * [Arch Linux^AUR (thanks to @mmetak)](https://aur.archlinux.org/packages/marker-git/)
 * [Arch Linux package (thanks to @City-busz)](https://www.archlinux.org/packages/community/x86_64/marker/)
 * [Ubuntu PPA (thanks to @apandada1 and @olivierb2)](https://launchpad.net/~apandada1/+archive/ubuntu/marker)


### PR DESCRIPTION
Marker present and published in stable Flathub channel, Flathub Beta links do not have landing pages, which results in a 404 when opened in browser, changed link to point to stable release on Flathub.