### PR TITLE
Save window position, editor pane width and sidebar open/closed state in the preferences

### DIFF
--- a/data/com.github.fabiocolacio.marker.gschema.xml
+++ b/data/com.github.fabiocolacio.marker.gschema.xml
@@ -175,6 +175,11 @@
       <summary>Window height</summary>
     </key>
 
+    <key name="window-position" type="(ii)">
+      <default>(-1, -1)</default>
+      <summary>Window position (x, y)</summary>
+    </key>
+
     <key name="editor-pane-width" type="u">
       <default>450</default>
       <summary>Editor pane width (in Dual Pane mode)</summary>

--- a/data/com.github.fabiocolacio.marker.gschema.xml
+++ b/data/com.github.fabiocolacio.marker.gschema.xml
@@ -179,5 +179,10 @@
       <default>450</default>
       <summary>Editor pane width (in Dual Pane mode)</summary>
     </key>
+
+    <key name="show-sidebar" type="b">
+      <default>false</default>
+      <summary>Whether the sidebar is shown</summary>
+    </key>
   </schema>
 </schemalist>

--- a/data/com.github.fabiocolacio.marker.gschema.xml
+++ b/data/com.github.fabiocolacio.marker.gschema.xml
@@ -174,5 +174,10 @@
       <default>600</default>
       <summary>Window height</summary>
     </key>
+
+    <key name="editor-pane-width" type="u">
+      <default>450</default>
+      <summary>Editor pane width (in Dual Pane mode)</summary>
+    </key>
   </schema>
 </schemalist>

--- a/src/marker-editor.c
+++ b/src/marker-editor.c
@@ -436,6 +436,8 @@ marker_editor_set_view_mode (MarkerEditor   *editor,
     case DUAL_PANE_MODE:
       gtk_paned_add1 (GTK_PANED (paned), source_scroll);
       gtk_paned_add2 (GTK_PANED (paned), preview);
+      // load saved pane width from the preferences
+      gtk_paned_set_position (GTK_PANED (paned), marker_prefs_get_editor_pane_width ());
       gtk_widget_grab_focus (GTK_WIDGET (editor->source_view));
       break;
 
@@ -452,6 +454,22 @@ marker_editor_set_view_mode (MarkerEditor   *editor,
       break;
   }
 
+}
+
+
+guint
+marker_editor_get_pane_width (MarkerEditor *editor)
+{
+  // editor pane width is valid only for dual pane mode
+  if(marker_editor_get_view_mode (editor) == DUAL_PANE_MODE)
+  {
+    return gtk_paned_get_position (GTK_PANED (editor->paned));
+  }
+  else
+  {
+    // return last saved value
+    return marker_prefs_get_editor_pane_width ();
+  }
 }
 
 void

--- a/src/marker-editor.h
+++ b/src/marker-editor.h
@@ -52,6 +52,7 @@ MarkerEditor        *marker_editor_new_from_file                 (GFile         
 MarkerViewMode       marker_editor_get_view_mode                 (MarkerEditor       *editor);
 void                 marker_editor_set_view_mode                 (MarkerEditor       *editor,
                                                                   MarkerViewMode      view_mode);
+guint                marker_editor_get_pane_width                (MarkerEditor       *editor);
 void                 marker_editor_refresh_preview               (MarkerEditor       *editor);
 void                 marker_editor_open_file                     (MarkerEditor       *editor,
                                                                   GFile              *file);

--- a/src/marker-prefs.c
+++ b/src/marker-prefs.c
@@ -72,6 +72,20 @@ marker_prefs_set_window_height(guint height)
   g_settings_set_uint(prefs.window_settings, "window-height", height);
 }
 
+void
+marker_prefs_get_window_position(gint *pos_x,
+                                 gint *pos_y)
+{
+  g_settings_get(prefs.window_settings, "window-position", "(ii)", pos_x, pos_y);
+}
+
+void
+marker_prefs_set_window_position(gint pos_x,
+                                 gint pos_y)
+{
+  g_settings_set(prefs.window_settings, "window-position", "(ii)", pos_x, pos_y);
+}
+
 guint
 marker_prefs_get_editor_pane_width()
 {

--- a/src/marker-prefs.c
+++ b/src/marker-prefs.c
@@ -72,6 +72,18 @@ marker_prefs_set_window_height(guint height)
   g_settings_set_uint(prefs.window_settings, "window-height", height);
 }
 
+guint
+marker_prefs_get_editor_pane_width()
+{
+  return g_settings_get_uint(prefs.window_settings, "editor-pane-width");
+}
+
+void
+marker_prefs_set_editor_pane_width(guint width)
+{
+  g_settings_set_uint(prefs.window_settings, "editor-pane-width", width);
+}
+
 gboolean
 marker_prefs_get_use_syntax_theme()
 {

--- a/src/marker-prefs.c
+++ b/src/marker-prefs.c
@@ -85,6 +85,18 @@ marker_prefs_set_editor_pane_width(guint width)
 }
 
 gboolean
+marker_prefs_get_show_sidebar()
+{
+  return g_settings_get_boolean(prefs.window_settings, "show-sidebar");
+}
+
+void
+marker_prefs_set_show_sidebar(gboolean state)
+{
+  g_settings_set_boolean(prefs.window_settings, "show-sidebar", state);
+}
+
+gboolean
 marker_prefs_get_use_syntax_theme()
 {
   return g_settings_get_boolean(prefs.editor_settings, "enable-syntax-theme");

--- a/src/marker-prefs.h
+++ b/src/marker-prefs.h
@@ -38,6 +38,8 @@ guint                marker_prefs_get_window_height              (void);
 void                 marker_prefs_set_window_height              (guint               height);
 guint                marker_prefs_get_editor_pane_width          (void);
 void                 marker_prefs_set_editor_pane_width          (guint               width);
+gboolean             marker_prefs_get_show_sidebar               (void);
+void                 marker_prefs_set_show_sidebar               (gboolean            state);
 char                *marker_prefs_get_syntax_theme               (void);
 void                 marker_prefs_set_syntax_theme               (const char         *theme);
 gboolean             marker_prefs_get_use_syntax_theme           (void);

--- a/src/marker-prefs.h
+++ b/src/marker-prefs.h
@@ -36,6 +36,8 @@ guint                marker_prefs_get_window_width               (void);
 void                 marker_prefs_set_window_width               (guint               width);
 guint                marker_prefs_get_window_height              (void);
 void                 marker_prefs_set_window_height              (guint               height);
+guint                marker_prefs_get_editor_pane_width          (void);
+void                 marker_prefs_set_editor_pane_width          (guint               width);
 char                *marker_prefs_get_syntax_theme               (void);
 void                 marker_prefs_set_syntax_theme               (const char         *theme);
 gboolean             marker_prefs_get_use_syntax_theme           (void);

--- a/src/marker-prefs.h
+++ b/src/marker-prefs.h
@@ -36,6 +36,10 @@ guint                marker_prefs_get_window_width               (void);
 void                 marker_prefs_set_window_width               (guint               width);
 guint                marker_prefs_get_window_height              (void);
 void                 marker_prefs_set_window_height              (guint               height);
+void                 marker_prefs_get_window_position            (gint               *pos_x,
+                                                                  gint               *pos_y);
+void                 marker_prefs_set_window_position            (gint                pos_x,
+                                                                  gint                pos_y);
 guint                marker_prefs_get_editor_pane_width          (void);
 void                 marker_prefs_set_editor_pane_width          (guint               width);
 gboolean             marker_prefs_get_show_sidebar               (void);

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -162,6 +162,8 @@ action_sidebar (GSimpleAction *action,
     gboolean state = g_variant_get_boolean (value);
 
     g_simple_action_set_state (action, value);
+    // save whether the sidebar is shown
+    marker_prefs_set_show_sidebar (state);
 
     if (state) {
         marker_window_show_sidebar (MARKER_WINDOW (window));
@@ -842,6 +844,12 @@ marker_window_init (MarkerWindow *window)
   }
   gtk_window_set_default_size(GTK_WINDOW(window), width, height);
   gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER);
+
+  if (marker_prefs_get_show_sidebar())
+  {
+    // show sidebar and set the "Sidebar" button as activated
+    g_action_group_activate_action(G_ACTION_MAP (window), "sidebar", NULL);
+  }
   g_signal_connect(window, "delete-event", G_CALLBACK(window_deleted_event_cb), window);
 
   g_object_unref (builder);

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -1159,10 +1159,14 @@ marker_window_try_close (MarkerWindow *window)
 
   // Save window size in the preferences
   gint width, height;
-  gtk_window_get_size (window, &width, &height);
+  gtk_window_get_size (GTK_WINDOW (window), &width, &height);
   g_print ("saved window size: %d x %d\n", width, height);
   marker_prefs_set_window_width (width);
   marker_prefs_set_window_height (height);
+
+  guint editor_width = marker_editor_get_pane_width (window->active_editor);
+  g_print ("saved editor pane width: %d\n", editor_width);
+  marker_prefs_set_editor_pane_width (editor_width);
 
   if (rows > 0)
   {

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -845,6 +845,15 @@ marker_window_init (MarkerWindow *window)
   gtk_window_set_default_size(GTK_WINDOW(window), width, height);
   gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER);
 
+  gint pos_x = 0, pos_y = 0;
+  marker_prefs_get_window_position( &pos_x, &pos_y);
+  g_print ("window position loaded from the preferences: %d, %d\n", pos_x, pos_y);
+  // require restored window position to be positive
+  if (pos_y >= 0 && pos_x >= 0)
+  {
+    gtk_window_move (GTK_WINDOW(window), pos_x, pos_y);
+  }
+
   if (marker_prefs_get_show_sidebar())
   {
     // show sidebar and set the "Sidebar" button as activated
@@ -1165,12 +1174,17 @@ marker_window_try_close (MarkerWindow *window)
   GtkTreeModel * model = GTK_TREE_MODEL(window->documents_tree_store);
   gint rows = gtk_tree_model_iter_n_children (model, NULL);
 
-  // Save window size in the preferences
+  // Save window size and position in the preferences
   gint width, height;
   gtk_window_get_size (GTK_WINDOW (window), &width, &height);
   g_print ("saved window size: %d x %d\n", width, height);
   marker_prefs_set_window_width (width);
   marker_prefs_set_window_height (height);
+
+  gint pos_x = 0, pos_y = 0;
+  gtk_window_get_position(GTK_WINDOW (window), &pos_x, &pos_y);
+  g_print ("saved window position: %d, %d\n", pos_x, pos_y);
+  marker_prefs_set_window_position (pos_x, pos_y);
 
   guint editor_width = marker_editor_get_pane_width (window->active_editor);
   g_print ("saved editor pane width: %d\n", editor_width);


### PR DESCRIPTION
These changes add features requested in issue #309, specifically window position and sidebar open/closed state.
Editor pane width is remembered too, so it is possible to "split the window always at 50%" (if you don't resize the window),
which was also requested in the issue.
