### PR TITLE
meson: Bump webkit2gtk dependency to 4.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,12 +82,12 @@ deps = [
   dependency('gtk+-3.0', version : '>=3.20'),
   dependency('glib-2.0'),
   dependency('gtksourceview-3.0'),
-  dependency('webkit2gtk-4.0'),
+  dependency('webkit2gtk-4.1'),
   dependency('gtkspell3-3.0')
 ]
 
 ext_deps =[
-  dependency('webkit2gtk-4.0')
+  dependency('webkit2gtk-4.1')
 ]
 
 add_global_arguments(


### PR DESCRIPTION
webkit2gtk-4.1 is compatible with webkit2gtk-4.0, the difference is that it links with libsoup3 instead of libsoup2.
It is required for bumping the flatpak's runtime to GNOME 43.