### PR TITLE
Several translation related patches

### DIFF
--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -5,9 +5,7 @@
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>Marker</name>
-  <name xml:lang="ko">마커</name>
   <summary>Powerful markdown editor for the GNOME desktop.</summary>
-  <summary xml:lang="ko">그놈 데스크탑을 위한 강력한 마크다운 편집기입니다.</summary>
 
   <description>
     <p>Features:</p>

--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -59,7 +59,7 @@
 
   <releases>
     <release version="2020.04.04" date="2020-04-04">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fixed a bug where equations weren't being rendered properly.</li>
           <li>Improved localizations.</li>
@@ -67,7 +67,7 @@
       </description>
     </release>
     <release version="2019.11.06" date="2019-11-06">
-        <description>
+        <description translatable="no">
             <ul>
                 <li>Preview stick to the editing text better.</li>
                 <li>Fixed crash on file opening.</li>
@@ -76,7 +76,7 @@
         </description>
    </release>
     <release version="2018.07.03" date="2018-07-03">
-        <description>
+        <description translatable="no">
             <ul>
                 <li>Added ability to export documents from the cli.</li>
                 <li>Added vim-like shortcuts (h,j,k,l,g,G) to the previewer.</li>
@@ -88,7 +88,7 @@
         </description>
    </release>
    <release version="2018.04.27" date="2018-04-27">
-        <description>
+        <description translatable="no">
             <ul>
                 <li>Added right-to-left language support</li>
                 <li>Added support for beamer classes for making presentations</li>
@@ -99,7 +99,7 @@
    <release version="2018.03.09" date="2018-03-09">
    </release>
    <release version="2018.01.23" date="2018-01-23">
-      <description>
+      <description translatable="no">
         <p>Initial Flathub release</p>
       </description>
     </release>

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,3 +1,6 @@
+data/com.github.fabiocolacio.marker.desktop
+data/com.github.fabiocolacio.marker.appdata.xml
+data/com.github.fabiocolacio.marker.gschema.xml
 src/resources/ui/marker-appmenu.ui
 src/resources/ui/marker-prefs-window.ui
 src/resources/ui/marker-shortcuts-window.ui

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -10,4 +10,5 @@ src/resources/ui/marker-window-main-view.ui
 src/resources/ui/marker-headerbar.ui
 src/marker.c
 src/marker-editor.c
+src/marker-exporter.c
 src/marker-window.c

--- a/po/marker.pot
+++ b/po/marker.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: marker\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-15 17:13+0100\n"
+"POT-Creation-Date: 2023-10-06 17:59+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,320 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: data/com.github.fabiocolacio.marker.desktop:3
+#: data/com.github.fabiocolacio.marker.appdata.xml:7
+msgid "Marker"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.desktop:11
+msgid "Markdown Editor"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.desktop:12
+msgid "A simple markdown editor for GTK+"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.desktop:26
+msgid "marker;markdown;editor;web;"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:8
+msgid "Powerful markdown editor for the GNOME desktop."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:11
+msgid "Features:"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:13
+msgid "View and edit markdown documents"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:14
+msgid "Convert markdown documents to HTML"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:15
+msgid "Tex math rendering"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:16
+msgid "Support for mermaid diagrams"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:17
+msgid "Support for charter plots"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:18
+msgid "Syntax highlighting for code blocks"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:19
+msgid "Integrated sketch editor"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:22
+msgid "PDF"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:23
+msgid "RTF"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:24
+msgid "ODT"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:25
+msgid "DOCx"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:26
+msgid "LaTeX"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:29
+msgid "Custom CSS themes"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:30
+msgid "Custom syntax themes"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:31
+msgid "Figure captioning and numbering"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:39
+msgid "The main view"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:43
+msgid "Some plotting"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.appdata.xml:47
+msgid "The sketch editor"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:24
+msgid "Syntax Theme"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:25
+msgid "The syntax theme to use for the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:30
+msgid "Enable Syntax Theme"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:31
+msgid "Whether to use a syntax theme in the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:36
+msgid "Show Line Numbers"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:37
+msgid "Whether to show line numbers in the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:42
+msgid "Show Right Margin"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:43
+msgid "Whether to show a margin on the right side of the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:48
+msgid "The column at which the right margin should be shown"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:49
+msgid ""
+"Sets the column where the right margin will appear when 'show-right-margin' "
+"is enabled"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:54
+msgid "Wrap Text"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:55
+msgid "Whether to wrap text in the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:60
+msgid "Show Spaces"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:61
+msgid "Whether to show spaces and tabulation in the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:66
+msgid "Highlight Current Line"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:67
+msgid "Whether to highlight the line with the cursor in the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:72
+msgid "Use spaces instead of tabs"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:73
+msgid "Use spaces instead of tabs in the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:78
+msgid "Width of tabulation in characters."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:79
+msgid "Set the width of tabulation in characters in the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:84
+msgid "Auto-indent code"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:85
+msgid "Auto-indent code in the editor."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:90
+msgid "Spell Check"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:91
+msgid "Spell check using gtkspell."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:96
+msgid "Language for spell check"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:97
+msgid "Selected language for spell check."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:104
+msgid "CSS Theme"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:105
+msgid "The css theme to use for the preview."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:110
+msgid "Enable CSS theme in Preview"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:111
+msgid "Use a CSS theme in the live preview"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:116
+msgid "Enable math in Preview"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:117
+msgid "Use js back-end to render math in the live preview."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:122
+msgid "Math Back-end"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:123
+msgid "Select the js math rendering back-end."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:128
+msgid "Enable highlight.js in Preview"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:129
+msgid "Use highlight.js in the live preview."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:134
+msgid "Enable mermaid.js in Preview"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:135
+msgid "Use mermaid.js to show diagram in the live preview."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:140
+msgid "Highlight.js CSS theme."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:141
+msgid "The css theme to use for the synthax highlight."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:145
+msgid "Enable Charter extension in Preview"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:146
+msgid "Enable Charter extension in the live preview."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:150
+msgid "Zoom level of the preview"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:151
+msgid "Zoom level of the preview widget"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:158
+#: src/resources/ui/marker-gear-popover.ui:168
+#: src/resources/ui/marker-gear-popover.ui:234
+msgid "View Mode"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:159
+msgid "Controls how to organize the editor and preview areas on the screen."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:164
+msgid "Enter dark-mode"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:165
+msgid ""
+"When this is enabled, the dark variant of the current gtk theme will be used."
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:170
+msgid "Window width"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:175
+msgid "Window height"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:180
+msgid "Window position (x, y)"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:185
+msgid "Editor pane width (in Dual Pane mode)"
+msgstr ""
+
+#: data/com.github.fabiocolacio.marker.gschema.xml:190
+msgid "Whether the sidebar is shown"
+msgstr ""
+
 #: src/resources/ui/marker-appmenu.ui:6
 #: src/resources/ui/marker-gear-popover.ui:88
 msgid "New Window"
@@ -24,7 +338,7 @@ msgstr ""
 
 #: src/resources/ui/marker-appmenu.ui:12
 #: src/resources/ui/marker-prefs-window.ui:46
-#: src/resources/ui/marker-gear-popover.ui:183
+#: src/resources/ui/marker-gear-popover.ui:191
 msgid "Preferences"
 msgstr ""
 
@@ -218,6 +532,11 @@ msgctxt "shortcut window"
 msgid "Insert link"
 msgstr ""
 
+#: src/resources/ui/marker-shortcuts-window.ui:95
+msgctxt "shortcut window"
+msgid "Draw a sketch"
+msgstr ""
+
 #: src/resources/ui/marker-shortcuts-window.ui:102
 msgctxt "shortcut window"
 msgid "Search in the document"
@@ -338,11 +657,6 @@ msgstr ""
 msgid "Print…"
 msgstr ""
 
-#: src/resources/ui/marker-gear-popover.ui:168
-#: src/resources/ui/marker-gear-popover.ui:234
-msgid "View Mode"
-msgstr ""
-
 #: src/resources/ui/marker-gear-popover.ui:215
 msgid "About Marker"
 msgstr ""
@@ -369,4 +683,48 @@ msgstr ""
 
 #: src/marker-editor.c:248
 msgid "Untitled.md"
+msgstr ""
+
+#: src/marker-exporter.c:106 src/marker-exporter.c:110
+msgid "Export"
+msgstr ""
+
+#: src/marker-exporter.c:109
+msgid "Cancel"
+msgstr ""
+
+#: src/marker-window.c:112
+#, c-format
+msgid ""
+"<span weight='bold' size='larger'>Discard changes to the document '%s'?</"
+"span>\n"
+"\n"
+"The document has unsaved changes that will be lost if it is closed now."
+msgstr ""
+
+#: src/marker-window.c:125
+msgid ""
+"<span weight='bold' size='larger'>Discard changes to the document?</span>\n"
+"\n"
+"The document has unsaved changes that will be lost if it is closed now."
+msgstr ""
+
+#: src/marker-window.c:1058 src/marker-window.c:1075
+msgid "Open"
+msgstr ""
+
+#: src/marker-window.c:1061 src/marker-window.c:1078
+msgid "_Open"
+msgstr ""
+
+#: src/marker-window.c:1061 src/marker-window.c:1078 src/marker-window.c:1096
+msgid "_Cancel"
+msgstr ""
+
+#: src/marker-window.c:1093
+msgid "Save As"
+msgstr ""
+
+#: src/marker-window.c:1096
+msgid "_Save"
 msgstr ""

--- a/src/marker-exporter.c
+++ b/src/marker-exporter.c
@@ -103,11 +103,11 @@ marker_exporter_export_pandoc(const char*        markdown,
 void
 marker_exporter_show_export_dialog(MarkerWindow* window)
 {
-  GtkDialog *dialog = GTK_DIALOG(gtk_file_chooser_dialog_new ("Export",
+  GtkDialog *dialog = GTK_DIALOG(gtk_file_chooser_dialog_new (_("Export"),
                                                               GTK_WINDOW(window),
                                                               GTK_FILE_CHOOSER_ACTION_SAVE,
-                                                              "Cancel", GTK_RESPONSE_CANCEL,
-                                                              "Export", GTK_RESPONSE_ACCEPT,
+                                                              _("Cancel"), GTK_RESPONSE_CANCEL,
+                                                              _("Export"), GTK_RESPONSE_ACCEPT,
                                                               NULL));
 
   GtkFileChooser *chooser = GTK_FILE_CHOOSER (dialog);

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -109,11 +109,11 @@ show_unsaved_documents_warning (MarkerWindow *window)
                                                 GTK_DIALOG_MODAL,
                                                 GTK_MESSAGE_WARNING,
                                                 GTK_BUTTONS_NONE,
-                                                "<span weight='bold' size='larger'>"
+                                                _("<span weight='bold' size='larger'>"
                                                 "Discard changes to the document '%s'?"
                                                 "</span>\n\n"
                                                 "The document has unsaved changes "
-                                                "that will be lost if it is closed now.",
+                                                "that will be lost if it is closed now."),
                                                 filename);
   }
   else
@@ -122,11 +122,11 @@ show_unsaved_documents_warning (MarkerWindow *window)
                                                 GTK_DIALOG_MODAL,
                                                 GTK_MESSAGE_WARNING,
                                                 GTK_BUTTONS_NONE,
-                                                "<span weight='bold' size='larger'>"
+                                                _("<span weight='bold' size='larger'>"
                                                 "Discard changes to the document?"
                                                 "</span>\n\n"
                                                 "The document has unsaved changes "
-                                                "that will be lost if it is closed now.");
+                                                "that will be lost if it is closed now."));
   }
 
   gtk_dialog_add_buttons(GTK_DIALOG (dialog),
@@ -1055,10 +1055,10 @@ marker_window_open_file (MarkerWindow *window)
 {
   g_assert (MARKER_IS_WINDOW (window));
 
-  g_autoptr (GtkFileChooserNative) dialog = gtk_file_chooser_native_new ("Open",
+  g_autoptr (GtkFileChooserNative) dialog = gtk_file_chooser_native_new (_("Open"),
                                                               GTK_WINDOW (window),
                                                               GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                              "_Open", "_Cancel");
+                                                              _("_Open"), _("_Cancel"));
   gint response = gtk_native_dialog_run (GTK_NATIVE_DIALOG (dialog));
 
   if (response == GTK_RESPONSE_ACCEPT)
@@ -1072,10 +1072,10 @@ void
 marker_window_open_file_in_new_window (MarkerWindow *window)
 {
   g_assert (MARKER_IS_WINDOW (window));
-  g_autoptr (GtkFileChooserNative) dialog = gtk_file_chooser_native_new ("Open",
+  g_autoptr (GtkFileChooserNative) dialog = gtk_file_chooser_native_new (_("Open"),
                                                               GTK_WINDOW (window),
                                                               GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                              "_Open", "_Cancel");
+                                                              _("_Open"), _("_Cancel"));
 
   gint response = gtk_native_dialog_run (GTK_NATIVE_DIALOG (dialog));
 
@@ -1090,10 +1090,10 @@ void
 marker_window_save_active_file_as (MarkerWindow *window)
 {
   g_assert (MARKER_IS_WINDOW (window));
-  g_autoptr (GtkFileChooserNative) dialog = gtk_file_chooser_native_new ("Save As",
+  g_autoptr (GtkFileChooserNative) dialog = gtk_file_chooser_native_new (_("Save As"),
                                                                          GTK_WINDOW (window),
                                                                          GTK_FILE_CHOOSER_ACTION_SAVE,
-                                                                         "_Save", "_Cancel");
+                                                                         _("_Save"), _("_Cancel"));
 
   gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
 


### PR DESCRIPTION
Please review individually. 

- gschema.xml contains numerous strings. We might consider omitting them due to their low priority in translation.
- I encountered difficulties while attempting to build Marker because the flatpak manifest was outdated.