### PR TITLE
appdata: Remove nested list from description

### DIFF
--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -17,15 +17,7 @@
       <li>Support for charter plots</li>
       <li>Syntax highlighting for code blocks</li>
       <li>Integrated sketch editor</li>
-      <li>Exports to
-        <ul>
-          <li>PDF</li>
-          <li>RTF</li>
-          <li>ODT</li>
-          <li>DOCx</li>
-          <li>LaTeX</li>
-        </ul>
-      </li>
+      <li>Exports to PDF, RTF, ODT, DOCx and LaTeX</li>
       <li>Custom CSS themes</li>
       <li>Custom syntax themes</li>
       <li>Figure captioning and numbering</li>


### PR DESCRIPTION
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description says:

> Nested lists are not supported

and, indeed, the nested list is simply not shown on the Flathub website or in GNOME Software, leading to a broken description.