### PR TITLE
appdata: `translate=no` properties and appdata improvements

### DIFF
--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -59,7 +59,7 @@
 
   <releases>
     <release version="2020.04.04" date="2020-04-04">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixed a bug where equations weren't being rendered properly.</li>
           <li>Improved localizations.</li>
@@ -67,7 +67,7 @@
       </description>
     </release>
     <release version="2019.11.06" date="2019-11-06">
-        <description translatable="no">
+        <description translate="no">
             <ul>
                 <li>Preview stick to the editing text better.</li>
                 <li>Fixed crash on file opening.</li>
@@ -76,7 +76,7 @@
         </description>
    </release>
     <release version="2018.07.03" date="2018-07-03">
-        <description translatable="no">
+        <description translate="no">
             <ul>
                 <li>Added ability to export documents from the cli.</li>
                 <li>Added vim-like shortcuts (h,j,k,l,g,G) to the previewer.</li>
@@ -88,7 +88,7 @@
         </description>
    </release>
    <release version="2018.04.27" date="2018-04-27">
-        <description translatable="no">
+        <description translate="no">
             <ul>
                 <li>Added right-to-left language support</li>
                 <li>Added support for beamer classes for making presentations</li>
@@ -99,7 +99,7 @@
    <release version="2018.03.09" date="2018-03-09">
    </release>
    <release version="2018.01.23" date="2018-01-23">
-      <description translatable="no">
+      <description translate="no">
         <p>Initial Flathub release</p>
       </description>
     </release>

--- a/data/com.github.fabiocolacio.marker.appdata.xml
+++ b/data/com.github.fabiocolacio.marker.appdata.xml
@@ -17,15 +17,7 @@
       <li>Support for charter plots</li>
       <li>Syntax highlighting for code blocks</li>
       <li>Integrated sketch editor</li>
-      <li>Exports to
-        <ul>
-          <li>PDF</li>
-          <li>RTF</li>
-          <li>ODT</li>
-          <li>DOCx</li>
-          <li>LaTeX</li>
-        </ul>
-      </li>
+      <li>Exports to PDF, RTF, ODT, DOCx and LaTeX</li>
       <li>Custom CSS themes</li>
       <li>Custom syntax themes</li>
       <li>Figure captioning and numbering</li>
@@ -33,6 +25,7 @@
   </description>
 
   <launchable type="desktop-id">com.github.fabiocolacio.marker.desktop</launchable>
+  <translation type="gettext">marker</translation>
 
   <screenshots>
     <screenshot type="default">
@@ -50,7 +43,9 @@
   </screenshots>
 
   <url type="homepage">https://github.com/fabiocolacio/Marker</url>
-  <project_group>Marker</project_group>
+  <url type="bugtracker">https://github.com/fabiocolacio/Marker/issues</url>
+  <url type="vcs-browser">https://github.com/fabiocolacio/Marker</url>
+  <url type="translate">https://github.com/fabiocolacio/Marker/tree/master/po</url>
 
   <provides>
     <binary>marker</binary>
@@ -105,34 +100,6 @@
     </release>
   </releases>
 
- <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
-  
+ <content_rating type="oars-1.1" />
+
 </component>


### PR DESCRIPTION
### appdata: `translate=no` properties

It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Improve appdata

- Fix broken markup in li tag
- Add vcs-browser and translate URLs
- Remove the none OARS ratings
- Add translation tag
- Remove incorrect project_group tag
