### PR TITLE
Fix incompatible pointer in marker_window_init()

### DIFF
--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -866,7 +866,7 @@ marker_window_init (MarkerWindow *window)
   if (marker_prefs_get_show_sidebar())
   {
     // show sidebar and set the "Sidebar" button as activated
-    g_action_group_activate_action(G_ACTION_MAP (window), "sidebar", NULL);
+    g_action_group_activate_action(G_ACTION_GROUP (window), "sidebar", NULL);
   }
   g_signal_connect(window, "delete-event", G_CALLBACK(window_deleted_event_cb), window);
 


### PR DESCRIPTION
The `g_action_group_activate_action()` takes `GActionGroup` as first parameter.

This fixes compilation with `-Wincompatible-pointer-types`.