### PR TITLE
Fix build: Add some missing includes causing build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,17 @@ Marker is a markdown editor for linux made with GTK+-3.0
 
 ### Build Instructions
 
-**NOTE: MAKE SURE TO CLEAN THE EXTENSIONS BEFORE UPDATING: rm /usr/share/com.github.fabiocolacio.marker/extensions/**
+**NOTE: MAKE SURE TO CLEAN THE EXTENSIONS BEFORE UPDATING:
+
+```bash
+rm /usr/share/com.github.fabiocolacio.marker/extensions/**
+```
 
 **Note:** For a more stable experience, users are recommended download
 [release tarball](https://github.com/fabiocolacio/Marker/releases) rather
 than cloning from master.
 
-```
+```bash
 $ git clone https://github.com/fabiocolacio/Marker.git
 $ cd Marker
 $ git submodule update --init --recursive

--- a/src/marker-exporter.c
+++ b/src/marker-exporter.c
@@ -24,6 +24,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <glib/gi18n.h>
+
 #include "marker.h"
 #include "marker-utils.h"
 #include "marker-string.h"

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -29,6 +29,7 @@
 
 #include <glib.h>
 #include <glib/gprintf.h>
+#include <glib/gi18n.h>
 
 #define MIN_DELTA_T 1
 


### PR DESCRIPTION
The build was failing on Fedora 43 due to some missing includes.  This fixes it.

Also tweaked README.md formatting for clearing extensions (it was hard to read before)