### PR TITLE
Add reload action with undo-friendly buffer replace

### DIFF
--- a/src/marker-editor.c
+++ b/src/marker-editor.c
@@ -512,6 +512,51 @@ marker_editor_open_file (MarkerEditor *editor,
 }
 
 void
+marker_editor_reload_file (MarkerEditor *editor)
+{
+  g_assert (MARKER_IS_EDITOR (editor));
+
+  GFile *file = marker_editor_get_file (editor);
+
+  if (!file)
+  {
+    return;
+  }
+
+  g_autofree gchar *file_contents = NULL;
+  gsize file_size = 0;
+  GError *err = NULL;
+
+  g_file_load_contents (file, NULL, &file_contents, &file_size, NULL, &err);
+
+  if (err)
+  {
+    g_warning ("Unable to reload file: %s", err->message);
+    g_error_free (err);
+    return;
+  }
+
+  MarkerSourceView *source_view = editor->source_view;
+  GtkSourceBuffer *buffer =
+    GTK_SOURCE_BUFFER (gtk_text_view_get_buffer (GTK_TEXT_VIEW (source_view)));
+
+  g_signal_handlers_block_by_func (buffer, buffer_changed_cb, editor);
+
+  gtk_text_buffer_begin_user_action (GTK_TEXT_BUFFER (buffer));
+  marker_source_view_set_text (source_view, file_contents, file_size);
+  gtk_text_buffer_end_user_action (GTK_TEXT_BUFFER (buffer));
+
+  g_signal_handlers_unblock_by_func (buffer, buffer_changed_cb, editor);
+
+  editor->unsaved_changes = FALSE;
+  editor->needs_refresh = TRUE;
+  editor->text_iter = NULL;
+
+  emit_signal_title_changed (editor);
+  emit_signal_subtitle_changed (editor);
+}
+
+void
 marker_editor_save_file (MarkerEditor *editor)
 {
   g_assert (MARKER_IS_EDITOR (editor));

--- a/src/marker-editor.h
+++ b/src/marker-editor.h
@@ -59,6 +59,7 @@ void                 marker_editor_open_file                     (MarkerEditor  
 void                 marker_editor_save_file                     (MarkerEditor       *editor);
 void                 marker_editor_save_file_as                  (MarkerEditor       *editor,
                                                                   GFile              *file);
+void                 marker_editor_reload_file                   (MarkerEditor       *editor);
 gboolean             marker_editor_rename_file                   (MarkerEditor       *editor,
                                                                   gchar*              name);
 GFile               *marker_editor_get_file                      (MarkerEditor       *editor);

--- a/src/marker-source-view.c
+++ b/src/marker-source-view.c
@@ -27,6 +27,8 @@
 #include "marker-utils.h"
 
 #include <glib.h>
+#include <gio/gio.h>
+#include <glib/gi18n.h>
 #include <gtkspell/gtkspell.h>
 
 struct _MarkerSourceView
@@ -253,6 +255,32 @@ default_font_changed(GSettings*   settings,
 }
 
 static void
+reload_menu_item_activate_cb (GtkMenuItem *menuitem,
+                              gpointer     user_data)
+{
+  MarkerSourceView *source_view = MARKER_SOURCE_VIEW (user_data);
+  GtkWidget *toplevel = gtk_widget_get_toplevel (GTK_WIDGET (source_view));
+
+  if (G_IS_ACTION_GROUP (toplevel))
+  {
+    g_action_group_activate_action (G_ACTION_GROUP (toplevel), "reload", NULL);
+  }
+}
+
+static void
+marker_source_view_populate_popup (GtkTextView *text_view,
+                                   GtkWidget   *menu,
+                                   gpointer     user_data)
+{
+  GtkWidget *reload_item = gtk_menu_item_new_with_mnemonic (_("_Reload from Disk"));
+  g_signal_connect (reload_item, "activate",
+                    G_CALLBACK (reload_menu_item_activate_cb), user_data);
+
+  gtk_menu_shell_append (GTK_MENU_SHELL (menu), reload_item);
+  gtk_widget_show (reload_item);
+}
+
+static void
 marker_source_view_init (MarkerSourceView *source_view)
 {
   GtkSourceSearchContext * search_context = gtk_source_search_context_new(GTK_SOURCE_BUFFER(gtk_text_view_get_buffer(GTK_TEXT_VIEW(source_view))),
@@ -277,6 +305,11 @@ marker_source_view_init (MarkerSourceView *source_view)
   if (marker_prefs_get_spell_check ()){
     gtk_spell_checker_attach (source_view->spell, GTK_TEXT_VIEW (source_view));
   }
+
+  g_signal_connect (source_view,
+                    "populate-popup",
+                    G_CALLBACK (marker_source_view_populate_popup),
+                    source_view);
 }
 
 static void

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -276,6 +276,29 @@ action_print (GSimpleAction *action,
 }
 
 static void
+action_reload (GSimpleAction *action,
+               GVariant      *parameter,
+               gpointer       user_data)
+{
+  MarkerWindow *window = user_data;
+  MarkerEditor *editor = marker_window_get_active_editor (window);
+
+  g_return_if_fail (MARKER_IS_EDITOR (editor));
+
+  if (marker_editor_has_unsaved_changes (editor))
+  {
+    gboolean discard = show_unsaved_documents_warning (window);
+
+    if (!discard)
+    {
+      return;
+    }
+  }
+
+  marker_editor_reload_file (editor);
+}
+
+static void
 action_editor_only_mode (GSimpleAction *action,
                          GVariant      *parameter,
                          gpointer       user_data)
@@ -675,6 +698,12 @@ marker_window_init (MarkerWindow *window)
     g_signal_connect_swapped (G_SIMPLE_ACTION (action), "activate", G_CALLBACK (marker_window_open_file), window);
     const gchar *open_accels[] = { "<Ctrl>o", NULL }; 
     gtk_application_set_accels_for_action (app, "win.open", open_accels);
+    g_action_map_add_action (G_ACTION_MAP (window), action);
+
+    action = G_ACTION (g_simple_action_new ("reload", NULL));
+    g_signal_connect (G_SIMPLE_ACTION (action), "activate", G_CALLBACK (action_reload), window);
+    const gchar *reload_accels[] = { "F5", "<Ctrl>r", NULL };
+    gtk_application_set_accels_for_action (app, "win.reload", reload_accels);
     g_action_map_add_action (G_ACTION_MAP (window), action);
 
     action = G_ACTION (g_simple_action_new ("save", NULL));

--- a/src/resources/ui/marker-gear-popover.ui
+++ b/src/resources/ui/marker-gear-popover.ui
@@ -138,6 +138,14 @@
               </object>
             </child>
             <child>
+              <object class="GtkModelButton" id="reload_btn">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="text" translatable="yes">Reload from Disk</property>
+                <property name="action-name">win.reload</property>
+              </object>
+            </child>
+            <child>
               <object class="GtkModelButton" id="export_btn">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>

--- a/src/resources/ui/marker-shortcuts-window.ui
+++ b/src/resources/ui/marker-shortcuts-window.ui
@@ -29,6 +29,20 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
+                <property name="accelerator">F5</property>
+                <property name="title" translatable="yes" context="shortcut window">Reload document from disk</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
+                <property name="accelerator">&lt;ctrl&gt;r</property>
+                <property name="title" translatable="yes" context="shortcut window">Reload document from disk</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
                 <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;o</property>
                 <property name="title" translatable="yes" context="shortcut window">Open a document in a new window</property>
               </object>


### PR DESCRIPTION
- add marker_editor_reload_file() to re-read the current file while keeping the undo stack intact (block change handler, wrap replace in one user action)
- new win.reload action with F5/Ctrl+R accelerators and unsaved-changes prompt
- expose Reload in the gear popover, shortcuts window, and editor context menu so it’s reachable via mouse and keyboard